### PR TITLE
Fix deprecated SPDX license identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   {name = "Iktae Kim", email = "iktae.kim@childmind.org"},
   {name = "Adam Santorelli", email = "adam.santorelli@childmind.org"}
 ]
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Updates deprecated SPDX license identifiers to fix build failures.

- `LGPL-2.1` → `LGPL-2.1-only`