### PR TITLE
104 Add Grid model and segment_strokes utility function 

### DIFF
--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -247,8 +247,7 @@ class Grid:
         n_cells = n_rows * n_cols
         if labels is not None and len(labels) != n_cells:
             raise ValueError(
-                f"labels length ({len(labels)}) must match "
-                f"n_rows * n_cols ({n_cells})."
+                f"labels length ({len(labels)}) must match n_rows * n_cols ({n_cells})."
             )
 
         padded_x_min = x_min - padding

--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -220,8 +220,9 @@ class Grid:
         """Create a Grid by subdividing a bounding box into rows and columns.
 
         Cells are generated in row-major order (left-to-right, top-to-bottom).
-        A small padding is added to the outer boundaries so that centroids
-        falling exactly on the outermost edge are still captured by a cell.
+        Interior cell boundaries are exact subdivisions of the bounding box;
+        only the outermost edges are extended by ``padding`` so that centroids
+        falling exactly on the outer boundary are still captured by a cell.
 
         Args:
             x_min: Left boundary of the bounding box.
@@ -232,8 +233,8 @@ class Grid:
             n_cols: Number of columns in the grid.
             labels: Optional list of labels for each cell, assigned in
                 row-major order. Must have length n_rows * n_cols if provided.
-            padding: Amount to extend the outer boundaries to capture edge
-                centroids (default 0.1).
+            padding: Amount to extend the outermost cell edges to capture edge
+                centroids; interior boundaries are unaffected (default 0.1).
 
         Returns:
             A Grid instance populated with GridCell objects.
@@ -250,22 +251,29 @@ class Grid:
                 f"labels length ({len(labels)}) must match n_rows * n_cols ({n_cells})."
             )
 
-        padded_x_min = x_min - padding
-        padded_x_max = x_max + padding
-        padded_y_min = y_min - padding
-        padded_y_max = y_max + padding
-
-        col_width = (padded_x_max - padded_x_min) / n_cols
-        row_height = (padded_y_max - padded_y_min) / n_rows
+        col_width = (x_max - x_min) / n_cols
+        row_height = (y_max - y_min) / n_rows
 
         cells: List[GridCell] = []
         index = 0
         for row in range(n_rows):
             for col in range(n_cols):
-                cell_x_min = padded_x_min + col * col_width
-                cell_x_max = padded_x_min + (col + 1) * col_width
-                cell_y_min = padded_y_max - (row + 1) * row_height
-                cell_y_max = padded_y_max - row * row_height
+                cell_x_min = x_min + col * col_width
+                if col == 0:
+                    cell_x_min -= padding
+
+                cell_x_max = x_min + (col + 1) * col_width
+                if col == n_cols - 1:
+                    cell_x_max += padding
+
+                cell_y_min = y_max - (row + 1) * row_height
+                if row == n_rows - 1:
+                    cell_y_min -= padding
+
+                cell_y_max = y_max - row * row_height
+                if row == 0:
+                    cell_y_max += padding
+
                 label = labels[index] if labels is not None else ""
                 cells.append(
                     GridCell(

--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -192,6 +192,117 @@ class GridCell:
 
 
 @dataclasses.dataclass
+class Grid:
+    """Represents a rectangular grid composed of multiple GridCell objects.
+
+    The grid divides a bounding box into rows and columns, where each cell can
+    hold strokes assigned by centroid location. Cells are ordered left-to-right,
+    top-to-bottom (row-major order).
+
+    Attributes:
+        cells: List of GridCell objects that compose the grid.
+    """
+
+    cells: List[GridCell] = dataclasses.field(default_factory=list)
+
+    @classmethod
+    def from_bbox(
+        cls,
+        x_min: float,
+        x_max: float,
+        y_min: float,
+        y_max: float,
+        n_rows: int,
+        n_cols: int,
+        labels: Optional[List[str]] = None,
+        padding: float = 0.1,
+    ) -> "Grid":
+        """Create a Grid by subdividing a bounding box into rows and columns.
+
+        Cells are generated in row-major order (left-to-right, top-to-bottom).
+        A small padding is added to the outer boundaries so that centroids
+        falling exactly on the outermost edge are still captured by a cell.
+
+        Args:
+            x_min: Left boundary of the bounding box.
+            x_max: Right boundary of the bounding box.
+            y_min: Bottom boundary of the bounding box.
+            y_max: Top boundary of the bounding box.
+            n_rows: Number of rows in the grid.
+            n_cols: Number of columns in the grid.
+            labels: Optional list of labels for each cell, assigned in
+                row-major order. Must have length n_rows * n_cols if provided.
+            padding: Amount to extend the outer boundaries to capture edge
+                centroids (default 0.1).
+
+        Returns:
+            A Grid instance populated with GridCell objects.
+
+        Raises:
+            ValueError: If n_rows or n_cols is less than 1, or if the length
+                of labels does not match n_rows * n_cols.
+        """
+        if n_rows < 1 or n_cols < 1:
+            raise ValueError("n_rows and n_cols must be at least 1.")
+        n_cells = n_rows * n_cols
+        if labels is not None and len(labels) != n_cells:
+            raise ValueError(
+                f"labels length ({len(labels)}) must match "
+                f"n_rows * n_cols ({n_cells})."
+            )
+
+        padded_x_min = x_min - padding
+        padded_x_max = x_max + padding
+        padded_y_min = y_min - padding
+        padded_y_max = y_max + padding
+
+        col_width = (padded_x_max - padded_x_min) / n_cols
+        row_height = (padded_y_max - padded_y_min) / n_rows
+
+        cells: List[GridCell] = []
+        index = 0
+        for row in range(n_rows):
+            for col in range(n_cols):
+                cell_x_min = padded_x_min + col * col_width
+                cell_x_max = padded_x_min + (col + 1) * col_width
+                cell_y_min = padded_y_max - (row + 1) * row_height
+                cell_y_max = padded_y_max - row * row_height
+                label = labels[index] if labels is not None else ""
+                cells.append(
+                    GridCell(
+                        x_min=cell_x_min,
+                        x_max=cell_x_max,
+                        y_min=cell_y_min,
+                        y_max=cell_y_max,
+                        index=index,
+                        label=label,
+                    )
+                )
+                index += 1
+
+        return cls(cells=cells)
+
+    def get_cell_for_point(self, x: float, y: float) -> int:
+        """Return the index of the cell containing the given point.
+
+        Iterates through cells and returns the index of the first cell whose
+        half-open interval [min, max) contains the point. Returns -1 if no
+        cell contains the point.
+
+        Args:
+            x: X coordinate of the point.
+            y: Y coordinate of the point.
+
+        Returns:
+            The index of the matching cell, or -1 if no cell contains the point.
+        """
+        for cell in self.cells:
+            if cell.x_min <= x < cell.x_max and cell.y_min <= y < cell.y_max:
+                return cell.index
+        return -1
+
+
+@dataclasses.dataclass
 class Stroke:
     """Represents a single stroke in an Alphabet or DSYM task.
 

--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -143,7 +143,9 @@ class GridCell:
         y_min: Bottom boundary of the cell.
         y_max: Top boundary of the cell.
         index: Position of the cell in the grid (0-based).
-        label: Display label for the cell (e.g., 'A', 'B', '1').
+        label: Display label for the cell (e.g., 'A', 'B', '1'). Defaults to an
+            empty string, which marks the cell as unlabeled (used for purely
+            spatial grids where cells are identified by index rather than name).
         strokes: List of Stroke objects assigned to this cell.
     """
 
@@ -233,6 +235,8 @@ class Grid:
             n_cols: Number of columns in the grid.
             labels: Optional list of labels for each cell, assigned in
                 row-major order. Must have length n_rows * n_cols if provided.
+                If omitted, every cell is left with an empty-string label,
+                marking the grid as unlabeled (cells identified by index only).
             padding: Amount to extend the outermost cell edges to capture edge
                 centroids; interior boundaries are unaffected (default 0.1).
 

--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -144,8 +144,10 @@ class GridCell:
         y_max: Top boundary of the cell.
         index: Position of the cell in the grid (0-based).
         label: Display label for the cell (e.g., 'A', 'B', '1'). Defaults to an
-            empty string, which marks the cell as unlabeled (used for purely
-            spatial grids where cells are identified by index rather than name).
+            empty string, which marks the cell as unlabeled: either a purely
+            spatial grid where cells are identified by index rather than name,
+            or a cell that is not of interest for the analysis (e.g., a spacer
+            or ignored region that no stroke should be attributed to).
         strokes: List of Stroke objects assigned to this cell.
     """
 
@@ -237,6 +239,8 @@ class Grid:
                 row-major order. Must have length n_rows * n_cols if provided.
                 If omitted, every cell is left with an empty-string label,
                 marking the grid as unlabeled (cells identified by index only).
+                An empty label also denotes a cell that is not of interest for
+                the analysis (e.g., a spacer or ignored region).
             padding: Amount to extend the outermost cell edges to capture edge
                 centroids; interior boundaries are unaffected (default 0.1).
 

--- a/src/graphomotor/utils/alphabet_utils.py
+++ b/src/graphomotor/utils/alphabet_utils.py
@@ -19,16 +19,14 @@ def segment_strokes(
 ) -> models.Grid:
     """Segment drawing data into strokes and assign them to grid cells.
 
-    Groups the data by ``line_number`` to create individual
-    :class:`~graphomotor.core.models.Stroke` objects. Each stroke is assigned
-    to a :class:`~graphomotor.core.models.GridCell` based on its centroid
-    (mean x, mean y). The grid is constructed via
-    :meth:`~graphomotor.core.models.Grid.from_bbox` with default padding so
-    that centroids on the outermost edge are captured.
+    Groups the data by line_number to create individual Stroke objects. Each
+    stroke is assigned to a GridCell based on its centroid (mean x, mean y).
+    The grid is constructed via Grid.from_bbox with default padding so that
+    centroids on the outermost edge are captured.
 
     Args:
-        data: DataFrame containing drawing data with at least ``line_number``,
-            ``x``, ``y``, and ``seconds`` columns.
+        data: DataFrame containing drawing data with at least line_number,
+            x, y, and seconds columns.
         x_min: Left boundary of the grid bounding box.
         x_max: Right boundary of the grid bounding box.
         y_min: Bottom boundary of the grid bounding box.
@@ -36,11 +34,10 @@ def segment_strokes(
         n_rows: Number of rows in the grid.
         n_cols: Number of columns in the grid.
         labels: Optional list of labels for each cell in row-major order.
-            Must have length ``n_rows * n_cols`` if provided.
+            Must have length n_rows * n_cols if provided.
 
     Returns:
-        A :class:`~graphomotor.core.models.Grid` populated with strokes
-        assigned to their matching cells.
+        A Grid populated with strokes assigned to their matching cells.
     """
     grid = models.Grid.from_bbox(
         x_min=x_min,

--- a/src/graphomotor/utils/alphabet_utils.py
+++ b/src/graphomotor/utils/alphabet_utils.py
@@ -1,0 +1,68 @@
+"""Utility functions for Alphabet and DSYM stroke segmentation."""
+
+from typing import List, Optional
+
+import pandas as pd
+
+from graphomotor.core import models
+
+
+def segment_strokes(
+    data: pd.DataFrame,
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
+    n_rows: int,
+    n_cols: int,
+    labels: Optional[List[str]] = None,
+) -> models.Grid:
+    """Segment drawing data into strokes and assign them to grid cells.
+
+    Groups the data by ``line_number`` to create individual
+    :class:`~graphomotor.core.models.Stroke` objects. Each stroke is assigned
+    to a :class:`~graphomotor.core.models.GridCell` based on its centroid
+    (mean x, mean y). The grid is constructed via
+    :meth:`~graphomotor.core.models.Grid.from_bbox` with default padding so
+    that centroids on the outermost edge are captured.
+
+    Args:
+        data: DataFrame containing drawing data with at least ``line_number``,
+            ``x``, ``y``, and ``seconds`` columns.
+        x_min: Left boundary of the grid bounding box.
+        x_max: Right boundary of the grid bounding box.
+        y_min: Bottom boundary of the grid bounding box.
+        y_max: Top boundary of the grid bounding box.
+        n_rows: Number of rows in the grid.
+        n_cols: Number of columns in the grid.
+        labels: Optional list of labels for each cell in row-major order.
+            Must have length ``n_rows * n_cols`` if provided.
+
+    Returns:
+        A :class:`~graphomotor.core.models.Grid` populated with strokes
+        assigned to their matching cells.
+    """
+    grid = models.Grid.from_bbox(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        labels=labels,
+    )
+
+    for line_number, group in data.groupby("line_number"):
+        stroke = models.Stroke(
+            points=group.reset_index(drop=True),
+            line_number=int(line_number),
+        )
+
+        centroid_x = group["x"].mean()
+        centroid_y = group["y"].mean()
+        cell_index = grid.get_cell_for_point(centroid_x, centroid_y)
+
+        if cell_index != -1:
+            grid.cells[cell_index].strokes.append(stroke)
+
+    return grid

--- a/tests/unit/test_alphabet_utils.py
+++ b/tests/unit/test_alphabet_utils.py
@@ -1,0 +1,148 @@
+"""Test cases for the segment_strokes utility function."""
+
+import pandas as pd
+
+from graphomotor.utils import alphabet_utils
+
+
+def _make_drawing_data() -> pd.DataFrame:
+    """Create drawing data with three strokes in distinct spatial regions.
+
+    Stroke 0 has centroid near (5, 85) - top-left of a 2x2 grid.
+    Stroke 1 has centroid near (55, 85) - top-right.
+    Stroke 2 has centroid near (5, 15) - bottom-left.
+    """
+    return pd.DataFrame(
+        {
+            "line_number": [0, 0, 0, 1, 1, 1, 2, 2, 2],
+            "x": [3.0, 5.0, 7.0, 53.0, 55.0, 57.0, 3.0, 5.0, 7.0],
+            "y": [83.0, 85.0, 87.0, 83.0, 85.0, 87.0, 13.0, 15.0, 17.0],
+            "seconds": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        }
+    )
+
+
+class TestSegmentStrokes:
+    """Tests for the segment_strokes function."""
+
+    def test_strokes_assigned_to_correct_cells(self) -> None:
+        """Each stroke should be placed in the cell containing its centroid."""
+        data = _make_drawing_data()
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
+            n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"],
+        )
+
+        assert len(grid.cells[0].strokes) == 1
+        assert grid.cells[0].strokes[0].line_number == 0
+        assert len(grid.cells[1].strokes) == 1
+        assert grid.cells[1].strokes[0].line_number == 1
+        assert len(grid.cells[2].strokes) == 1
+        assert grid.cells[2].strokes[0].line_number == 2
+        assert len(grid.cells[3].strokes) == 0
+
+    def test_total_stroke_count_matches_line_numbers(self) -> None:
+        """Total strokes across all cells should equal the number of line groups."""
+        data = _make_drawing_data()
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
+            n_rows=2, n_cols=2,
+        )
+
+        total_strokes = sum(len(c.strokes) for c in grid.cells)
+        assert total_strokes == 3
+
+    def test_stroke_points_are_correct(self) -> None:
+        """Each Stroke should contain the correct subset of points."""
+        data = _make_drawing_data()
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
+            n_rows=2, n_cols=2,
+        )
+
+        stroke_0 = grid.cells[0].strokes[0]
+        assert len(stroke_0.points) == 3
+        assert list(stroke_0.points["x"]) == [3.0, 5.0, 7.0]
+
+    def test_empty_dataframe(self) -> None:
+        """An empty DataFrame should produce a grid with no strokes."""
+        data = pd.DataFrame(columns=["line_number", "x", "y", "seconds"])
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=1, n_cols=1,
+        )
+
+        assert all(len(c.strokes) == 0 for c in grid.cells)
+
+    def test_stroke_outside_grid_is_not_assigned(self) -> None:
+        """Strokes whose centroids fall outside the grid should be dropped."""
+        data = pd.DataFrame(
+            {
+                "line_number": [0, 0],
+                "x": [500.0, 600.0],
+                "y": [500.0, 600.0],
+                "seconds": [0.0, 0.1],
+            }
+        )
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=1, n_cols=1,
+        )
+
+        assert len(grid.cells[0].strokes) == 0
+
+    def test_multiple_strokes_in_same_cell(self) -> None:
+        """Multiple strokes in the same spatial region should all land in one cell."""
+        data = pd.DataFrame(
+            {
+                "line_number": [0, 0, 1, 1, 2, 2],
+                "x": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
+                "y": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
+                "seconds": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+            }
+        )
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=1, n_cols=1,
+        )
+
+        assert len(grid.cells[0].strokes) == 3
+
+    def test_grid_structure_matches_parameters(self) -> None:
+        """Returned grid should have the correct number of labeled cells."""
+        data = _make_drawing_data()
+        labels = ["A", "B", "C", "D", "E", "F"]
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
+            n_rows=2, n_cols=3, labels=labels,
+        )
+
+        assert len(grid.cells) == 6
+        assert [c.label for c in grid.cells] == labels
+
+    def test_stroke_index_is_reset(self) -> None:
+        """Stroke points should have a reset index starting from 0."""
+        data = pd.DataFrame(
+            {
+                "line_number": [5, 5, 5],
+                "x": [1.0, 2.0, 3.0],
+                "y": [1.0, 2.0, 3.0],
+                "seconds": [0.0, 0.1, 0.2],
+            },
+            index=[10, 11, 12],
+        )
+        grid = alphabet_utils.segment_strokes(
+            data=data,
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=1, n_cols=1,
+        )
+
+        stroke = grid.cells[0].strokes[0]
+        assert list(stroke.points.index) == [0, 1, 2]

--- a/tests/unit/test_alphabet_utils.py
+++ b/tests/unit/test_alphabet_utils.py
@@ -1,16 +1,19 @@
 """Test cases for the segment_strokes utility function."""
 
 import pandas as pd
+import pytest
 
 from graphomotor.utils import alphabet_utils
 
 
-def _make_drawing_data() -> pd.DataFrame:
-    """Create drawing data with three strokes in distinct spatial regions.
+@pytest.fixture
+def drawing_data() -> pd.DataFrame:
+    """Drawing data with three strokes in distinct spatial regions.
 
-    Stroke 0 has centroid near (5, 85) - top-left of a 2x2 grid.
-    Stroke 1 has centroid near (55, 85) - top-right.
-    Stroke 2 has centroid near (5, 15) - bottom-left.
+    On a 2x2 grid over [0, 100]:
+    - Stroke 0 has centroid near (5, 85): top-left cell.
+    - Stroke 1 has centroid near (55, 85): top-right cell.
+    - Stroke 2 has centroid near (5, 15): bottom-left cell.
     """
     return pd.DataFrame(
         {
@@ -22,161 +25,172 @@ def _make_drawing_data() -> pd.DataFrame:
     )
 
 
-class TestSegmentStrokes:
-    """Tests for the segment_strokes function."""
+def test_strokes_assigned_to_correct_cells(drawing_data: pd.DataFrame) -> None:
+    """Each stroke is placed in the cell containing its centroid."""
+    grid = alphabet_utils.segment_strokes(
+        data=drawing_data,
+        x_min=0.0,
+        x_max=100.0,
+        y_min=0.0,
+        y_max=100.0,
+        n_rows=2,
+        n_cols=2,
+        labels=["TL", "TR", "BL", "BR"],
+    )
 
-    def test_strokes_assigned_to_correct_cells(self) -> None:
-        """Each stroke should be placed in the cell containing its centroid."""
-        data = _make_drawing_data()
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=100.0,
-            y_min=0.0,
-            y_max=100.0,
-            n_rows=2,
-            n_cols=2,
-            labels=["TL", "TR", "BL", "BR"],
-        )
+    assert len(grid.cells[0].strokes) == 1
+    assert grid.cells[0].strokes[0].line_number == 0
+    assert len(grid.cells[1].strokes) == 1
+    assert grid.cells[1].strokes[0].line_number == 1
+    assert len(grid.cells[2].strokes) == 1
+    assert grid.cells[2].strokes[0].line_number == 2
+    assert len(grid.cells[3].strokes) == 0
 
-        assert len(grid.cells[0].strokes) == 1
-        assert grid.cells[0].strokes[0].line_number == 0
-        assert len(grid.cells[1].strokes) == 1
-        assert grid.cells[1].strokes[0].line_number == 1
-        assert len(grid.cells[2].strokes) == 1
-        assert grid.cells[2].strokes[0].line_number == 2
-        assert len(grid.cells[3].strokes) == 0
 
-    def test_total_stroke_count_matches_line_numbers(self) -> None:
-        """Total strokes across all cells should equal the number of line groups."""
-        data = _make_drawing_data()
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=100.0,
-            y_min=0.0,
-            y_max=100.0,
-            n_rows=2,
-            n_cols=2,
-        )
+def test_total_stroke_count_matches_line_numbers(drawing_data: pd.DataFrame) -> None:
+    """Total strokes across all cells equal the number of line_number groups."""
+    grid = alphabet_utils.segment_strokes(
+        data=drawing_data,
+        x_min=0.0,
+        x_max=100.0,
+        y_min=0.0,
+        y_max=100.0,
+        n_rows=2,
+        n_cols=2,
+    )
 
-        total_strokes = sum(len(c.strokes) for c in grid.cells)
-        assert total_strokes == 3
+    total_strokes = sum(len(cell.strokes) for cell in grid.cells)
+    assert total_strokes == drawing_data["line_number"].nunique()
 
-    def test_stroke_points_are_correct(self) -> None:
-        """Each Stroke should contain the correct subset of points."""
-        data = _make_drawing_data()
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=100.0,
-            y_min=0.0,
-            y_max=100.0,
-            n_rows=2,
-            n_cols=2,
-        )
 
-        stroke_0 = grid.cells[0].strokes[0]
-        assert len(stroke_0.points) == 3
-        assert list(stroke_0.points["x"]) == [3.0, 5.0, 7.0]
+def test_stroke_points_are_correct(drawing_data: pd.DataFrame) -> None:
+    """Every stroke contains exactly the points of its line_number group."""
+    grid = alphabet_utils.segment_strokes(
+        data=drawing_data,
+        x_min=0.0,
+        x_max=100.0,
+        y_min=0.0,
+        y_max=100.0,
+        n_rows=2,
+        n_cols=2,
+    )
 
-    def test_empty_dataframe(self) -> None:
-        """An empty DataFrame should produce a grid with no strokes."""
-        data = pd.DataFrame(columns=["line_number", "x", "y", "seconds"])
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=1,
-            n_cols=1,
-        )
+    strokes_by_line = {
+        stroke.line_number: stroke for cell in grid.cells for stroke in cell.strokes
+    }
+    assert sorted(strokes_by_line) == [0, 1, 2]
+    for line_number, stroke in strokes_by_line.items():
+        expected = drawing_data[drawing_data["line_number"] == line_number]
+        assert list(stroke.points["x"]) == list(expected["x"])
+        assert list(stroke.points["y"]) == list(expected["y"])
+        assert list(stroke.points["seconds"]) == list(expected["seconds"])
 
-        assert all(len(c.strokes) == 0 for c in grid.cells)
 
-    def test_stroke_outside_grid_is_not_assigned(self) -> None:
-        """Strokes whose centroids fall outside the grid should be dropped."""
-        data = pd.DataFrame(
-            {
-                "line_number": [0, 0],
-                "x": [500.0, 600.0],
-                "y": [500.0, 600.0],
-                "seconds": [0.0, 0.1],
-            }
-        )
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=1,
-            n_cols=1,
-        )
+def test_empty_dataframe() -> None:
+    """An empty DataFrame produces a grid with no strokes."""
+    data = pd.DataFrame(columns=["line_number", "x", "y", "seconds"])
+    grid = alphabet_utils.segment_strokes(
+        data=data,
+        x_min=0.0,
+        x_max=10.0,
+        y_min=0.0,
+        y_max=10.0,
+        n_rows=1,
+        n_cols=1,
+    )
 
-        assert len(grid.cells[0].strokes) == 0
+    assert all(len(cell.strokes) == 0 for cell in grid.cells)
 
-    def test_multiple_strokes_in_same_cell(self) -> None:
-        """Multiple strokes in the same spatial region should all land in one cell."""
-        data = pd.DataFrame(
-            {
-                "line_number": [0, 0, 1, 1, 2, 2],
-                "x": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
-                "y": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
-                "seconds": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
-            }
-        )
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=1,
-            n_cols=1,
-        )
 
-        assert len(grid.cells[0].strokes) == 3
+def test_stroke_outside_grid_is_not_assigned() -> None:
+    """Strokes whose centroids fall outside the grid are dropped."""
+    data = pd.DataFrame(
+        {
+            "line_number": [0, 0],
+            "x": [500.0, 600.0],
+            "y": [500.0, 600.0],
+            "seconds": [0.0, 0.1],
+        }
+    )
+    grid = alphabet_utils.segment_strokes(
+        data=data,
+        x_min=0.0,
+        x_max=10.0,
+        y_min=0.0,
+        y_max=10.0,
+        n_rows=1,
+        n_cols=1,
+    )
 
-    def test_grid_structure_matches_parameters(self) -> None:
-        """Returned grid should have the correct number of labeled cells."""
-        data = _make_drawing_data()
-        labels = ["A", "B", "C", "D", "E", "F"]
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=100.0,
-            y_min=0.0,
-            y_max=100.0,
-            n_rows=2,
-            n_cols=3,
-            labels=labels,
-        )
+    assert len(grid.cells[0].strokes) == 0
 
-        assert len(grid.cells) == 6
-        assert [c.label for c in grid.cells] == labels
 
-    def test_stroke_index_is_reset(self) -> None:
-        """Stroke points should have a reset index starting from 0."""
-        data = pd.DataFrame(
-            {
-                "line_number": [5, 5, 5],
-                "x": [1.0, 2.0, 3.0],
-                "y": [1.0, 2.0, 3.0],
-                "seconds": [0.0, 0.1, 0.2],
-            },
-            index=[10, 11, 12],
-        )
-        grid = alphabet_utils.segment_strokes(
-            data=data,
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=1,
-            n_cols=1,
-        )
+def test_multiple_strokes_in_same_cell() -> None:
+    """Multiple strokes in the same spatial region all land in one cell."""
+    data = pd.DataFrame(
+        {
+            "line_number": [0, 0, 1, 1, 2, 2],
+            "x": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
+            "y": [5.0, 6.0, 5.5, 6.5, 4.5, 5.5],
+            "seconds": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+        }
+    )
+    grid = alphabet_utils.segment_strokes(
+        data=data,
+        x_min=0.0,
+        x_max=10.0,
+        y_min=0.0,
+        y_max=10.0,
+        n_rows=1,
+        n_cols=1,
+    )
 
-        stroke = grid.cells[0].strokes[0]
-        assert list(stroke.points.index) == [0, 1, 2]
+    assert len(grid.cells[0].strokes) == 3
+
+
+def test_grid_structure_matches_parameters(drawing_data: pd.DataFrame) -> None:
+    """Returned grid has the correct number of labeled cells."""
+    labels = ["A", "B", "C", "D", "E", "F"]
+    grid = alphabet_utils.segment_strokes(
+        data=drawing_data,
+        x_min=0.0,
+        x_max=100.0,
+        y_min=0.0,
+        y_max=100.0,
+        n_rows=2,
+        n_cols=3,
+        labels=labels,
+    )
+
+    assert len(grid.cells) == 6
+    assert [cell.label for cell in grid.cells] == labels
+
+
+def test_stroke_index_is_reset() -> None:
+    """Stroke points have a fresh 0-based index.
+
+    pandas groupby chunks keep the row indices of the parent DataFrame
+    (here 10-12); segment_strokes resets them so each stroke's points are
+    independently indexed from 0.
+    """
+    data = pd.DataFrame(
+        {
+            "line_number": [5, 5, 5],
+            "x": [1.0, 2.0, 3.0],
+            "y": [1.0, 2.0, 3.0],
+            "seconds": [0.0, 0.1, 0.2],
+        },
+        index=[10, 11, 12],
+    )
+    grid = alphabet_utils.segment_strokes(
+        data=data,
+        x_min=0.0,
+        x_max=10.0,
+        y_min=0.0,
+        y_max=10.0,
+        n_rows=1,
+        n_cols=1,
+    )
+
+    stroke = grid.cells[0].strokes[0]
+    assert list(stroke.points.index) == [0, 1, 2]

--- a/tests/unit/test_alphabet_utils.py
+++ b/tests/unit/test_alphabet_utils.py
@@ -30,8 +30,13 @@ class TestSegmentStrokes:
         data = _make_drawing_data()
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
-            n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"],
+            x_min=0.0,
+            x_max=100.0,
+            y_min=0.0,
+            y_max=100.0,
+            n_rows=2,
+            n_cols=2,
+            labels=["TL", "TR", "BL", "BR"],
         )
 
         assert len(grid.cells[0].strokes) == 1
@@ -47,8 +52,12 @@ class TestSegmentStrokes:
         data = _make_drawing_data()
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
-            n_rows=2, n_cols=2,
+            x_min=0.0,
+            x_max=100.0,
+            y_min=0.0,
+            y_max=100.0,
+            n_rows=2,
+            n_cols=2,
         )
 
         total_strokes = sum(len(c.strokes) for c in grid.cells)
@@ -59,8 +68,12 @@ class TestSegmentStrokes:
         data = _make_drawing_data()
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
-            n_rows=2, n_cols=2,
+            x_min=0.0,
+            x_max=100.0,
+            y_min=0.0,
+            y_max=100.0,
+            n_rows=2,
+            n_cols=2,
         )
 
         stroke_0 = grid.cells[0].strokes[0]
@@ -72,8 +85,12 @@ class TestSegmentStrokes:
         data = pd.DataFrame(columns=["line_number", "x", "y", "seconds"])
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=1, n_cols=1,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=1,
+            n_cols=1,
         )
 
         assert all(len(c.strokes) == 0 for c in grid.cells)
@@ -90,8 +107,12 @@ class TestSegmentStrokes:
         )
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=1, n_cols=1,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=1,
+            n_cols=1,
         )
 
         assert len(grid.cells[0].strokes) == 0
@@ -108,8 +129,12 @@ class TestSegmentStrokes:
         )
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=1, n_cols=1,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=1,
+            n_cols=1,
         )
 
         assert len(grid.cells[0].strokes) == 3
@@ -120,8 +145,13 @@ class TestSegmentStrokes:
         labels = ["A", "B", "C", "D", "E", "F"]
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=100.0, y_min=0.0, y_max=100.0,
-            n_rows=2, n_cols=3, labels=labels,
+            x_min=0.0,
+            x_max=100.0,
+            y_min=0.0,
+            y_max=100.0,
+            n_rows=2,
+            n_cols=3,
+            labels=labels,
         )
 
         assert len(grid.cells) == 6
@@ -140,8 +170,12 @@ class TestSegmentStrokes:
         )
         grid = alphabet_utils.segment_strokes(
             data=data,
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=1, n_cols=1,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=1,
+            n_cols=1,
         )
 
         stroke = grid.cells[0].strokes[0]

--- a/tests/unit/test_alphabet_utils.py
+++ b/tests/unit/test_alphabet_utils.py
@@ -26,7 +26,11 @@ def drawing_data() -> pd.DataFrame:
 
 
 def test_strokes_assigned_to_correct_cells(drawing_data: pd.DataFrame) -> None:
-    """Each stroke is placed in the cell containing its centroid."""
+    """Each stroke is placed in the labeled cell containing its centroid.
+
+    Also checks that the total number of assigned strokes equals the number of
+    line_number groups, so no stroke is dropped or duplicated.
+    """
     grid = alphabet_utils.segment_strokes(
         data=drawing_data,
         x_min=0.0,
@@ -37,7 +41,9 @@ def test_strokes_assigned_to_correct_cells(drawing_data: pd.DataFrame) -> None:
         n_cols=2,
         labels=["TL", "TR", "BL", "BR"],
     )
+    total_strokes = sum(len(cell.strokes) for cell in grid.cells)
 
+    assert [cell.label for cell in grid.cells] == ["TL", "TR", "BL", "BR"]
     assert len(grid.cells[0].strokes) == 1
     assert grid.cells[0].strokes[0].line_number == 0
     assert len(grid.cells[1].strokes) == 1
@@ -45,21 +51,6 @@ def test_strokes_assigned_to_correct_cells(drawing_data: pd.DataFrame) -> None:
     assert len(grid.cells[2].strokes) == 1
     assert grid.cells[2].strokes[0].line_number == 2
     assert len(grid.cells[3].strokes) == 0
-
-
-def test_total_stroke_count_matches_line_numbers(drawing_data: pd.DataFrame) -> None:
-    """Total strokes across all cells equal the number of line_number groups."""
-    grid = alphabet_utils.segment_strokes(
-        data=drawing_data,
-        x_min=0.0,
-        x_max=100.0,
-        y_min=0.0,
-        y_max=100.0,
-        n_rows=2,
-        n_cols=2,
-    )
-
-    total_strokes = sum(len(cell.strokes) for cell in grid.cells)
     assert total_strokes == drawing_data["line_number"].nunique()
 
 

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -1,23 +1,28 @@
 """Test cases for the Grid model."""
 
-from typing import Dict
-
 import pytest
 
 from graphomotor.core import models
 
 
 @pytest.fixture
-def bbox_kwargs() -> Dict[str, float]:
-    """Bounding box keyword arguments for a 10x10 grid area."""
-    return {"x_min": 0.0, "x_max": 10.0, "y_min": 0.0, "y_max": 10.0}
+def bbox_bounds() -> tuple[float, float, float, float]:
+    """Bounding box coordinates as (x_min, x_max, y_min, y_max)."""
+    return (0.0, 10.0, 0.0, 10.0)
 
 
 @pytest.fixture
-def grid_2x2(bbox_kwargs: Dict[str, float]) -> models.Grid:
+def grid_2x2(bbox_bounds: tuple[float, float, float, float]) -> models.Grid:
     """Create a labeled 2x2 grid over a 10x10 bounding box."""
+    x_min, x_max, y_min, y_max = bbox_bounds
     return models.Grid.from_bbox(
-        n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"], **bbox_kwargs
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        n_rows=2,
+        n_cols=2,
+        labels=["TL", "TR", "BL", "BR"],
     )
 
 
@@ -27,10 +32,18 @@ def grid_2x2(bbox_kwargs: Dict[str, float]) -> models.Grid:
     ids=["1x1", "2x2", "3x3", "2x3"],
 )
 def test_grid_structure(
-    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+    bbox_bounds: tuple[float, float, float, float], n_rows: int, n_cols: int
 ) -> None:
     """Grids have n_rows * n_cols cells in row-major order, tiling without gaps."""
-    grid = models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        n_rows=n_rows,
+        n_cols=n_cols,
+    )
 
     assert len(grid.cells) == n_rows * n_cols
     assert [cell.index for cell in grid.cells] == list(range(n_rows * n_cols))
@@ -70,10 +83,19 @@ def test_padding_only_extends_outer_boundaries() -> None:
 
 @pytest.mark.parametrize("padding", [0.1, 1.0], ids=["default", "custom"])
 def test_outer_boundaries_extended_by_padding(
-    bbox_kwargs: Dict[str, float], padding: float
+    bbox_bounds: tuple[float, float, float, float], padding: float
 ) -> None:
     """The outermost grid edges extend beyond the bounding box by the padding."""
-    grid = models.Grid.from_bbox(n_rows=1, n_cols=1, padding=padding, **bbox_kwargs)
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        n_rows=1,
+        n_cols=1,
+        padding=padding,
+    )
 
     cell = grid.cells[0]
     assert cell.x_min == pytest.approx(-padding)
@@ -87,17 +109,31 @@ def test_labels_assigned(grid_2x2: models.Grid) -> None:
     assert [cell.label for cell in grid_2x2.cells] == ["TL", "TR", "BL", "BR"]
 
 
-def test_labels_default_empty(bbox_kwargs: Dict[str, float]) -> None:
+def test_labels_default_empty(bbox_bounds: tuple[float, float, float, float]) -> None:
     """Cells have empty labels when none are provided."""
-    grid = models.Grid.from_bbox(n_rows=1, n_cols=2, **bbox_kwargs)
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, n_rows=1, n_cols=2
+    )
 
     assert all(cell.label == "" for cell in grid.cells)
 
 
-def test_labels_length_mismatch_raises(bbox_kwargs: Dict[str, float]) -> None:
+def test_labels_length_mismatch_raises(
+    bbox_bounds: tuple[float, float, float, float],
+) -> None:
     """Providing the wrong number of labels raises ValueError."""
+    x_min, x_max, y_min, y_max = bbox_bounds
     with pytest.raises(ValueError, match="labels length"):
-        models.Grid.from_bbox(n_rows=2, n_cols=2, labels=["A", "B"], **bbox_kwargs)
+        models.Grid.from_bbox(
+            x_min=x_min,
+            x_max=x_max,
+            y_min=y_min,
+            y_max=y_max,
+            n_rows=2,
+            n_cols=2,
+            labels=["A", "B"],
+        )
 
 
 @pytest.mark.parametrize(
@@ -106,16 +142,29 @@ def test_labels_length_mismatch_raises(bbox_kwargs: Dict[str, float]) -> None:
     ids=["zero_rows", "zero_cols", "both_zero", "negative_rows"],
 )
 def test_invalid_dimensions_raise(
-    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+    bbox_bounds: tuple[float, float, float, float], n_rows: int, n_cols: int
 ) -> None:
     """Non-positive row or column counts raise ValueError."""
+    x_min, x_max, y_min, y_max = bbox_bounds
     with pytest.raises(ValueError, match="n_rows and n_cols must be at least 1"):
-        models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
+        models.Grid.from_bbox(
+            x_min=x_min,
+            x_max=x_max,
+            y_min=y_min,
+            y_max=y_max,
+            n_rows=n_rows,
+            n_cols=n_cols,
+        )
 
 
-def test_default_strokes_are_empty(bbox_kwargs: Dict[str, float]) -> None:
+def test_default_strokes_are_empty(
+    bbox_bounds: tuple[float, float, float, float],
+) -> None:
     """All cells start with empty strokes lists."""
-    grid = models.Grid.from_bbox(n_rows=2, n_cols=3, **bbox_kwargs)
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, n_rows=2, n_cols=3
+    )
 
     assert all(cell.strokes == [] for cell in grid.cells)
 
@@ -126,17 +175,25 @@ def test_default_strokes_are_empty(bbox_kwargs: Dict[str, float]) -> None:
     ids=["2x2", "3x3", "2x4"],
 )
 def test_get_cell_for_point_maps_cell_centers(
-    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+    bbox_bounds: tuple[float, float, float, float], n_rows: int, n_cols: int
 ) -> None:
     """The center of every cell maps back to that cell's index."""
-    grid = models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
-    col_width = (bbox_kwargs["x_max"] - bbox_kwargs["x_min"]) / n_cols
-    row_height = (bbox_kwargs["y_max"] - bbox_kwargs["y_min"]) / n_rows
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        n_rows=n_rows,
+        n_cols=n_cols,
+    )
+    col_width = (x_max - x_min) / n_cols
+    row_height = (y_max - y_min) / n_rows
 
     for row in range(n_rows):
         for col in range(n_cols):
-            center_x = bbox_kwargs["x_min"] + (col + 0.5) * col_width
-            center_y = bbox_kwargs["y_max"] - (row + 0.5) * row_height
+            center_x = x_min + (col + 0.5) * col_width
+            center_y = y_max - (row + 0.5) * row_height
             assert grid.get_cell_for_point(center_x, center_y) == row * n_cols + col
 
 
@@ -156,10 +213,13 @@ def test_point_on_inner_boundary_ownership(grid_2x2: models.Grid) -> None:
 
 
 def test_point_on_outer_edge_captured_by_padding(
-    bbox_kwargs: Dict[str, float],
+    bbox_bounds: tuple[float, float, float, float],
 ) -> None:
     """Points on the exact bounding box corners are captured thanks to padding."""
-    grid = models.Grid.from_bbox(n_rows=1, n_cols=1, **bbox_kwargs)
+    x_min, x_max, y_min, y_max = bbox_bounds
+    grid = models.Grid.from_bbox(
+        x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, n_rows=1, n_cols=1
+    )
 
     assert grid.get_cell_for_point(0.0, 0.0) == 0
     assert grid.get_cell_for_point(10.0, 10.0) == 0

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -1,193 +1,172 @@
 """Test cases for the Grid model."""
 
+from typing import Dict
+
 import pytest
 
 from graphomotor.core import models
 
 
-class TestGridFromBbox:
-    """Tests for the Grid.from_bbox factory method."""
+@pytest.fixture
+def bbox_kwargs() -> Dict[str, float]:
+    """Bounding box keyword arguments for a 10x10 grid area."""
+    return {"x_min": 0.0, "x_max": 10.0, "y_min": 0.0, "y_max": 10.0}
 
-    def test_single_cell_grid(self) -> None:
-        """A 1x1 grid should produce exactly one cell covering the padded bbox."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=1
-        )
 
-        assert len(grid.cells) == 1
-        cell = grid.cells[0]
-        assert cell.index == 0
-        assert cell.x_min == pytest.approx(-0.1)
-        assert cell.x_max == pytest.approx(10.1)
-        assert cell.y_min == pytest.approx(-0.1)
-        assert cell.y_max == pytest.approx(10.1)
-
-    def test_two_by_two_grid_cell_count(self) -> None:
-        """A 2x2 grid should produce exactly four cells."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
-        )
-
-        assert len(grid.cells) == 4
-
-    def test_row_major_order(self) -> None:
-        """Cells should be ordered left-to-right, top-to-bottom."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
-        )
-
-        assert grid.cells[0].index == 0
-        assert grid.cells[1].index == 1
-        assert grid.cells[2].index == 2
-        assert grid.cells[3].index == 3
-
-        assert grid.cells[0].y_min > grid.cells[2].y_min
-        assert grid.cells[0].x_min < grid.cells[1].x_min
-
-    def test_labels_assigned(self) -> None:
-        """Labels should be assigned in row-major order when provided."""
-        labels = ["A", "B", "C", "D"]
-        grid = models.Grid.from_bbox(
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=2,
-            n_cols=2,
-            labels=labels,
-        )
-
-        assert [c.label for c in grid.cells] == ["A", "B", "C", "D"]
-
-    def test_labels_default_empty(self) -> None:
-        """Cells should have empty labels when none are provided."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=2
-        )
-
-        assert all(c.label == "" for c in grid.cells)
-
-    def test_labels_length_mismatch_raises(self) -> None:
-        """Providing the wrong number of labels should raise ValueError."""
-        with pytest.raises(ValueError, match="labels length"):
-            models.Grid.from_bbox(
-                x_min=0.0,
-                x_max=10.0,
-                y_min=0.0,
-                y_max=10.0,
-                n_rows=2,
-                n_cols=2,
-                labels=["A", "B"],
-            )
-
-    @pytest.mark.parametrize(
-        "n_rows,n_cols",
-        [(0, 1), (1, 0), (0, 0), (-1, 1)],
-        ids=["zero_rows", "zero_cols", "both_zero", "negative_rows"],
+@pytest.fixture
+def grid_2x2(bbox_kwargs: Dict[str, float]) -> models.Grid:
+    """Create a labeled 2x2 grid over a 10x10 bounding box."""
+    return models.Grid.from_bbox(
+        n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"], **bbox_kwargs
     )
-    def test_invalid_dimensions_raise(self, n_rows: int, n_cols: int) -> None:
-        """Non-positive row or column counts should raise ValueError."""
-        with pytest.raises(ValueError, match="n_rows and n_cols must be at least 1"):
-            models.Grid.from_bbox(
-                x_min=0.0,
-                x_max=10.0,
-                y_min=0.0,
-                y_max=10.0,
-                n_rows=n_rows,
-                n_cols=n_cols,
-            )
-
-    def test_custom_padding(self) -> None:
-        """Custom padding should extend the outer boundaries accordingly."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=1,
-            n_cols=1,
-            padding=1.0,
-        )
-
-        cell = grid.cells[0]
-        assert cell.x_min == pytest.approx(-1.0)
-        assert cell.x_max == pytest.approx(11.0)
-        assert cell.y_min == pytest.approx(-1.0)
-        assert cell.y_max == pytest.approx(11.0)
-
-    def test_cells_tile_without_gaps(self) -> None:
-        """Adjacent cells should share boundaries with no gaps or overlap."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
-        )
-
-        top_left, top_right = grid.cells[0], grid.cells[1]
-        bottom_left = grid.cells[2]
-
-        assert top_left.x_max == pytest.approx(top_right.x_min)
-        assert top_left.y_min == pytest.approx(bottom_left.y_max)
-
-    def test_default_strokes_are_empty(self) -> None:
-        """All cells should start with empty strokes lists."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=3
-        )
-
-        assert all(c.strokes == [] for c in grid.cells)
 
 
-class TestGetCellForPoint:
-    """Tests for Grid.get_cell_for_point."""
+@pytest.mark.parametrize(
+    "n_rows,n_cols",
+    [(1, 1), (2, 2), (3, 3), (2, 3)],
+    ids=["1x1", "2x2", "3x3", "2x3"],
+)
+def test_grid_structure(
+    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+) -> None:
+    """Grids have n_rows * n_cols cells in row-major order, tiling without gaps."""
+    grid = models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
 
-    @pytest.fixture
-    def grid_2x2(self) -> models.Grid:
-        """Create a 2x2 grid over the unit square with labels."""
-        return models.Grid.from_bbox(
-            x_min=0.0,
-            x_max=10.0,
-            y_min=0.0,
-            y_max=10.0,
-            n_rows=2,
-            n_cols=2,
-            labels=["TL", "TR", "BL", "BR"],
-        )
+    assert len(grid.cells) == n_rows * n_cols
+    assert [cell.index for cell in grid.cells] == list(range(n_rows * n_cols))
+    for row in range(n_rows):
+        for col in range(n_cols):
+            cell = grid.cells[row * n_cols + col]
+            if col > 0:
+                left_neighbor = grid.cells[row * n_cols + col - 1]
+                assert cell.x_min == pytest.approx(left_neighbor.x_max)
+            if row > 0:
+                upper_neighbor = grid.cells[(row - 1) * n_cols + col]
+                assert cell.y_max == pytest.approx(upper_neighbor.y_min)
 
-    def test_point_in_top_left(self, grid_2x2: models.Grid) -> None:
-        """Point in the top-left quadrant should return index 0."""
-        assert grid_2x2.get_cell_for_point(2.0, 8.0) == 0
 
-    def test_point_in_top_right(self, grid_2x2: models.Grid) -> None:
-        """Point in the top-right quadrant should return index 1."""
-        assert grid_2x2.get_cell_for_point(8.0, 8.0) == 1
+def test_padding_only_extends_outer_boundaries() -> None:
+    """Interior boundaries are exact subdivisions; only outer edges get padding.
 
-    def test_point_in_bottom_left(self, grid_2x2: models.Grid) -> None:
-        """Point in the bottom-left quadrant should return index 2."""
-        assert grid_2x2.get_cell_for_point(2.0, 2.0) == 2
+    For a 3x3 grid over [0, 30], interior boundaries must fall exactly on 10
+    and 20, while the outermost edges extend by the default padding of 0.1.
+    """
+    grid = models.Grid.from_bbox(
+        x_min=0.0, x_max=30.0, y_min=0.0, y_max=30.0, n_rows=3, n_cols=3
+    )
 
-    def test_point_in_bottom_right(self, grid_2x2: models.Grid) -> None:
-        """Point in the bottom-right quadrant should return index 3."""
-        assert grid_2x2.get_cell_for_point(8.0, 2.0) == 3
+    center = grid.cells[4]  # row 1, col 1: fully interior, no padding anywhere
+    assert center.x_min == pytest.approx(10.0)
+    assert center.x_max == pytest.approx(20.0)
+    assert center.y_min == pytest.approx(10.0)
+    assert center.y_max == pytest.approx(20.0)
 
-    def test_point_outside_grid(self, grid_2x2: models.Grid) -> None:
-        """Point far outside the grid should return -1."""
-        assert grid_2x2.get_cell_for_point(100.0, 100.0) == -1
+    middle_right = grid.cells[5]  # row 1, col 2: padded only on the right edge
+    assert middle_right.x_min == pytest.approx(20.0)
+    assert middle_right.x_max == pytest.approx(30.1)
+    assert middle_right.y_min == pytest.approx(10.0)
+    assert middle_right.y_max == pytest.approx(20.0)
 
-    def test_point_on_inner_boundary(self, grid_2x2: models.Grid) -> None:
-        """Point on an internal cell boundary belongs to the next cell."""
-        mid_x = (grid_2x2.cells[0].x_max + grid_2x2.cells[1].x_min) / 2
-        result = grid_2x2.get_cell_for_point(mid_x, 8.0)
-        assert result in (0, 1)
 
-    def test_point_on_outer_edge_captured_by_padding(self) -> None:
-        """Point on the exact data boundary should be inside due to padding."""
-        grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=1
-        )
+@pytest.mark.parametrize("padding", [0.1, 1.0], ids=["default", "custom"])
+def test_outer_boundaries_extended_by_padding(
+    bbox_kwargs: Dict[str, float], padding: float
+) -> None:
+    """The outermost grid edges extend beyond the bounding box by the padding."""
+    grid = models.Grid.from_bbox(n_rows=1, n_cols=1, padding=padding, **bbox_kwargs)
 
-        assert grid.get_cell_for_point(0.0, 0.0) == 0
-        assert grid.get_cell_for_point(10.0, 10.0) == 0
+    cell = grid.cells[0]
+    assert cell.x_min == pytest.approx(-padding)
+    assert cell.x_max == pytest.approx(10.0 + padding)
+    assert cell.y_min == pytest.approx(-padding)
+    assert cell.y_max == pytest.approx(10.0 + padding)
 
-    def test_empty_grid_returns_negative_one(self) -> None:
-        """Grid with no cells should always return -1."""
-        grid = models.Grid(cells=[])
-        assert grid.get_cell_for_point(5.0, 5.0) == -1
+
+def test_labels_assigned(grid_2x2: models.Grid) -> None:
+    """Labels are assigned in row-major order when provided."""
+    assert [cell.label for cell in grid_2x2.cells] == ["TL", "TR", "BL", "BR"]
+
+
+def test_labels_default_empty(bbox_kwargs: Dict[str, float]) -> None:
+    """Cells have empty labels when none are provided."""
+    grid = models.Grid.from_bbox(n_rows=1, n_cols=2, **bbox_kwargs)
+
+    assert all(cell.label == "" for cell in grid.cells)
+
+
+def test_labels_length_mismatch_raises(bbox_kwargs: Dict[str, float]) -> None:
+    """Providing the wrong number of labels raises ValueError."""
+    with pytest.raises(ValueError, match="labels length"):
+        models.Grid.from_bbox(n_rows=2, n_cols=2, labels=["A", "B"], **bbox_kwargs)
+
+
+@pytest.mark.parametrize(
+    "n_rows,n_cols",
+    [(0, 1), (1, 0), (0, 0), (-1, 1)],
+    ids=["zero_rows", "zero_cols", "both_zero", "negative_rows"],
+)
+def test_invalid_dimensions_raise(
+    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+) -> None:
+    """Non-positive row or column counts raise ValueError."""
+    with pytest.raises(ValueError, match="n_rows and n_cols must be at least 1"):
+        models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
+
+
+def test_default_strokes_are_empty(bbox_kwargs: Dict[str, float]) -> None:
+    """All cells start with empty strokes lists."""
+    grid = models.Grid.from_bbox(n_rows=2, n_cols=3, **bbox_kwargs)
+
+    assert all(cell.strokes == [] for cell in grid.cells)
+
+
+@pytest.mark.parametrize(
+    "n_rows,n_cols",
+    [(2, 2), (3, 3), (2, 4)],
+    ids=["2x2", "3x3", "2x4"],
+)
+def test_get_cell_for_point_maps_cell_centers(
+    bbox_kwargs: Dict[str, float], n_rows: int, n_cols: int
+) -> None:
+    """The center of every cell maps back to that cell's index."""
+    grid = models.Grid.from_bbox(n_rows=n_rows, n_cols=n_cols, **bbox_kwargs)
+    col_width = (bbox_kwargs["x_max"] - bbox_kwargs["x_min"]) / n_cols
+    row_height = (bbox_kwargs["y_max"] - bbox_kwargs["y_min"]) / n_rows
+
+    for row in range(n_rows):
+        for col in range(n_cols):
+            center_x = bbox_kwargs["x_min"] + (col + 0.5) * col_width
+            center_y = bbox_kwargs["y_max"] - (row + 0.5) * row_height
+            assert grid.get_cell_for_point(center_x, center_y) == row * n_cols + col
+
+
+def test_point_outside_grid_returns_negative_one(grid_2x2: models.Grid) -> None:
+    """A point far outside the grid returns -1."""
+    assert grid_2x2.get_cell_for_point(100.0, 100.0) == -1
+
+
+def test_point_on_inner_boundary_ownership(grid_2x2: models.Grid) -> None:
+    """Half-open intervals assign interior boundary points deterministically.
+
+    A point on a vertical interior boundary belongs to the cell on its right;
+    a point on a horizontal interior boundary belongs to the cell above it.
+    """
+    assert grid_2x2.get_cell_for_point(5.0, 8.0) == 1
+    assert grid_2x2.get_cell_for_point(2.0, 5.0) == 0
+
+
+def test_point_on_outer_edge_captured_by_padding(
+    bbox_kwargs: Dict[str, float],
+) -> None:
+    """Points on the exact bounding box corners are captured thanks to padding."""
+    grid = models.Grid.from_bbox(n_rows=1, n_cols=1, **bbox_kwargs)
+
+    assert grid.get_cell_for_point(0.0, 0.0) == 0
+    assert grid.get_cell_for_point(10.0, 10.0) == 0
+
+
+def test_empty_grid_returns_negative_one() -> None:
+    """A grid with no cells always returns -1."""
+    grid = models.Grid(cells=[])
+
+    assert grid.get_cell_for_point(5.0, 5.0) == -1

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -62,19 +62,29 @@ def test_grid_structure(
                 assert cell.y_max == pytest.approx(upper_neighbor.y_min)
 
 
-def test_padding_only_extends_outer_boundaries() -> None:
-    """Interior boundaries are exact subdivisions; only outer edges get padding.
+@pytest.mark.parametrize(
+    "padding", [0.1, 1.0], ids=["default_padding", "custom_padding"]
+)
+def test_cell_boundaries_interior_exact_outer_padded(padding: float) -> None:
+    """Interior edges are exact subdivisions; only outer edges extend by padding.
 
-    For a 3x3 grid over [0, 30] each cell spans 10 units. Every interior edge
-    must fall exactly on a multiple of 10, while the four outermost edges extend
-    by the default padding of 0.1. This loops over all nine cells and checks
-    each computed boundary against its expected value.
+    Builds a 3x3 grid over [0, 30] (each cell spans 10 units) and checks every
+    cell's four boundaries in one pass, covering all three boundary kinds:
+    - interior edges shared between neighbors fall exactly on multiples of 10,
+    - the four outermost edges extend beyond the bounding box by ``padding``,
+    - corner cells combine both (two exact interior edges, two padded outer).
+    Parameterizing padding exercises both the default and a custom value.
     """
-    padding = 0.1
     n_rows = n_cols = 3
     cell_size = 10.0
     grid = models.Grid.from_bbox(
-        x_min=0.0, x_max=30.0, y_min=0.0, y_max=30.0, n_rows=n_rows, n_cols=n_cols
+        x_min=0.0,
+        x_max=30.0,
+        y_min=0.0,
+        y_max=30.0,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        padding=padding,
     )
 
     for row in range(n_rows):
@@ -95,29 +105,6 @@ def test_padding_only_extends_outer_boundaries() -> None:
             assert cell.x_max == pytest.approx(expected_x_max)
             assert cell.y_min == pytest.approx(expected_y_min)
             assert cell.y_max == pytest.approx(expected_y_max)
-
-
-@pytest.mark.parametrize("padding", [0.1, 1.0], ids=["default", "custom"])
-def test_outer_boundaries_extended_by_padding(
-    bbox_bounds: tuple[float, float, float, float], padding: float
-) -> None:
-    """The outermost grid edges extend beyond the bounding box by the padding."""
-    x_min, x_max, y_min, y_max = bbox_bounds
-    grid = models.Grid.from_bbox(
-        x_min=x_min,
-        x_max=x_max,
-        y_min=y_min,
-        y_max=y_max,
-        n_rows=1,
-        n_cols=1,
-        padding=padding,
-    )
-
-    cell = grid.cells[0]
-    assert cell.x_min == pytest.approx(-padding)
-    assert cell.x_max == pytest.approx(10.0 + padding)
-    assert cell.y_min == pytest.approx(-padding)
-    assert cell.y_max == pytest.approx(10.0 + padding)
 
 
 def test_labels_assigned(grid_2x2: models.Grid) -> None:

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -1,0 +1,169 @@
+"""Test cases for the Grid model."""
+
+import pytest
+
+from graphomotor.core import models
+
+
+class TestGridFromBbox:
+    """Tests for the Grid.from_bbox factory method."""
+
+    def test_single_cell_grid(self) -> None:
+        """A 1x1 grid should produce exactly one cell covering the padded bbox."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=1
+        )
+
+        assert len(grid.cells) == 1
+        cell = grid.cells[0]
+        assert cell.index == 0
+        assert cell.x_min == pytest.approx(-0.1)
+        assert cell.x_max == pytest.approx(10.1)
+        assert cell.y_min == pytest.approx(-0.1)
+        assert cell.y_max == pytest.approx(10.1)
+
+    def test_two_by_two_grid_cell_count(self) -> None:
+        """A 2x2 grid should produce exactly four cells."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
+        )
+
+        assert len(grid.cells) == 4
+
+    def test_row_major_order(self) -> None:
+        """Cells should be ordered left-to-right, top-to-bottom."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
+        )
+
+        assert grid.cells[0].index == 0
+        assert grid.cells[1].index == 1
+        assert grid.cells[2].index == 2
+        assert grid.cells[3].index == 3
+
+        assert grid.cells[0].y_min > grid.cells[2].y_min
+        assert grid.cells[0].x_min < grid.cells[1].x_min
+
+    def test_labels_assigned(self) -> None:
+        """Labels should be assigned in row-major order when provided."""
+        labels = ["A", "B", "C", "D"]
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=2, n_cols=2, labels=labels,
+        )
+
+        assert [c.label for c in grid.cells] == ["A", "B", "C", "D"]
+
+    def test_labels_default_empty(self) -> None:
+        """Cells should have empty labels when none are provided."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=2
+        )
+
+        assert all(c.label == "" for c in grid.cells)
+
+    def test_labels_length_mismatch_raises(self) -> None:
+        """Providing the wrong number of labels should raise ValueError."""
+        with pytest.raises(ValueError, match="labels length"):
+            models.Grid.from_bbox(
+                x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+                n_rows=2, n_cols=2, labels=["A", "B"],
+            )
+
+    @pytest.mark.parametrize(
+        "n_rows,n_cols",
+        [(0, 1), (1, 0), (0, 0), (-1, 1)],
+        ids=["zero_rows", "zero_cols", "both_zero", "negative_rows"],
+    )
+    def test_invalid_dimensions_raise(self, n_rows: int, n_cols: int) -> None:
+        """Non-positive row or column counts should raise ValueError."""
+        with pytest.raises(ValueError, match="n_rows and n_cols must be at least 1"):
+            models.Grid.from_bbox(
+                x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+                n_rows=n_rows, n_cols=n_cols,
+            )
+
+    def test_custom_padding(self) -> None:
+        """Custom padding should extend the outer boundaries accordingly."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=1, n_cols=1, padding=1.0,
+        )
+
+        cell = grid.cells[0]
+        assert cell.x_min == pytest.approx(-1.0)
+        assert cell.x_max == pytest.approx(11.0)
+        assert cell.y_min == pytest.approx(-1.0)
+        assert cell.y_max == pytest.approx(11.0)
+
+    def test_cells_tile_without_gaps(self) -> None:
+        """Adjacent cells should share boundaries with no gaps or overlap."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=2
+        )
+
+        top_left, top_right = grid.cells[0], grid.cells[1]
+        bottom_left = grid.cells[2]
+
+        assert top_left.x_max == pytest.approx(top_right.x_min)
+        assert top_left.y_min == pytest.approx(bottom_left.y_max)
+
+    def test_default_strokes_are_empty(self) -> None:
+        """All cells should start with empty strokes lists."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=2, n_cols=3
+        )
+
+        assert all(c.strokes == [] for c in grid.cells)
+
+
+class TestGetCellForPoint:
+    """Tests for Grid.get_cell_for_point."""
+
+    @pytest.fixture
+    def grid_2x2(self) -> models.Grid:
+        """Create a 2x2 grid over the unit square with labels."""
+        return models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
+            n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"],
+        )
+
+    def test_point_in_top_left(self, grid_2x2: models.Grid) -> None:
+        """Point in the top-left quadrant should return index 0."""
+        assert grid_2x2.get_cell_for_point(2.0, 8.0) == 0
+
+    def test_point_in_top_right(self, grid_2x2: models.Grid) -> None:
+        """Point in the top-right quadrant should return index 1."""
+        assert grid_2x2.get_cell_for_point(8.0, 8.0) == 1
+
+    def test_point_in_bottom_left(self, grid_2x2: models.Grid) -> None:
+        """Point in the bottom-left quadrant should return index 2."""
+        assert grid_2x2.get_cell_for_point(2.0, 2.0) == 2
+
+    def test_point_in_bottom_right(self, grid_2x2: models.Grid) -> None:
+        """Point in the bottom-right quadrant should return index 3."""
+        assert grid_2x2.get_cell_for_point(8.0, 2.0) == 3
+
+    def test_point_outside_grid(self, grid_2x2: models.Grid) -> None:
+        """Point far outside the grid should return -1."""
+        assert grid_2x2.get_cell_for_point(100.0, 100.0) == -1
+
+    def test_point_on_inner_boundary(self, grid_2x2: models.Grid) -> None:
+        """Point on an internal cell boundary belongs to the next cell."""
+        mid_x = (grid_2x2.cells[0].x_max + grid_2x2.cells[1].x_min) / 2
+        result = grid_2x2.get_cell_for_point(mid_x, 8.0)
+        assert result in (0, 1)
+
+    def test_point_on_outer_edge_captured_by_padding(self) -> None:
+        """Point on the exact data boundary should be inside due to padding."""
+        grid = models.Grid.from_bbox(
+            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0, n_rows=1, n_cols=1
+        )
+
+        assert grid.get_cell_for_point(0.0, 0.0) == 0
+        assert grid.get_cell_for_point(10.0, 10.0) == 0
+
+    def test_empty_grid_returns_negative_one(self) -> None:
+        """Grid with no cells should always return -1."""
+        grid = models.Grid(cells=[])
+        assert grid.get_cell_for_point(5.0, 5.0) == -1

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -48,8 +48,13 @@ class TestGridFromBbox:
         """Labels should be assigned in row-major order when provided."""
         labels = ["A", "B", "C", "D"]
         grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=2, n_cols=2, labels=labels,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=2,
+            n_cols=2,
+            labels=labels,
         )
 
         assert [c.label for c in grid.cells] == ["A", "B", "C", "D"]
@@ -66,8 +71,13 @@ class TestGridFromBbox:
         """Providing the wrong number of labels should raise ValueError."""
         with pytest.raises(ValueError, match="labels length"):
             models.Grid.from_bbox(
-                x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-                n_rows=2, n_cols=2, labels=["A", "B"],
+                x_min=0.0,
+                x_max=10.0,
+                y_min=0.0,
+                y_max=10.0,
+                n_rows=2,
+                n_cols=2,
+                labels=["A", "B"],
             )
 
     @pytest.mark.parametrize(
@@ -79,15 +89,24 @@ class TestGridFromBbox:
         """Non-positive row or column counts should raise ValueError."""
         with pytest.raises(ValueError, match="n_rows and n_cols must be at least 1"):
             models.Grid.from_bbox(
-                x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-                n_rows=n_rows, n_cols=n_cols,
+                x_min=0.0,
+                x_max=10.0,
+                y_min=0.0,
+                y_max=10.0,
+                n_rows=n_rows,
+                n_cols=n_cols,
             )
 
     def test_custom_padding(self) -> None:
         """Custom padding should extend the outer boundaries accordingly."""
         grid = models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=1, n_cols=1, padding=1.0,
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=1,
+            n_cols=1,
+            padding=1.0,
         )
 
         cell = grid.cells[0]
@@ -124,8 +143,13 @@ class TestGetCellForPoint:
     def grid_2x2(self) -> models.Grid:
         """Create a 2x2 grid over the unit square with labels."""
         return models.Grid.from_bbox(
-            x_min=0.0, x_max=10.0, y_min=0.0, y_max=10.0,
-            n_rows=2, n_cols=2, labels=["TL", "TR", "BL", "BR"],
+            x_min=0.0,
+            x_max=10.0,
+            y_min=0.0,
+            y_max=10.0,
+            n_rows=2,
+            n_cols=2,
+            labels=["TL", "TR", "BL", "BR"],
         )
 
     def test_point_in_top_left(self, grid_2x2: models.Grid) -> None:

--- a/tests/unit/test_grid.py
+++ b/tests/unit/test_grid.py
@@ -50,9 +50,13 @@ def test_grid_structure(
     for row in range(n_rows):
         for col in range(n_cols):
             cell = grid.cells[row * n_cols + col]
+            # No horizontal gaps/overlaps: a cell's left edge meets the right
+            # edge of its left neighbor.
             if col > 0:
                 left_neighbor = grid.cells[row * n_cols + col - 1]
                 assert cell.x_min == pytest.approx(left_neighbor.x_max)
+            # No vertical gaps/overlaps: a cell's top edge meets the bottom edge
+            # of the neighbor above it (rows run top-to-bottom).
             if row > 0:
                 upper_neighbor = grid.cells[(row - 1) * n_cols + col]
                 assert cell.y_max == pytest.approx(upper_neighbor.y_min)
@@ -61,24 +65,36 @@ def test_grid_structure(
 def test_padding_only_extends_outer_boundaries() -> None:
     """Interior boundaries are exact subdivisions; only outer edges get padding.
 
-    For a 3x3 grid over [0, 30], interior boundaries must fall exactly on 10
-    and 20, while the outermost edges extend by the default padding of 0.1.
+    For a 3x3 grid over [0, 30] each cell spans 10 units. Every interior edge
+    must fall exactly on a multiple of 10, while the four outermost edges extend
+    by the default padding of 0.1. This loops over all nine cells and checks
+    each computed boundary against its expected value.
     """
+    padding = 0.1
+    n_rows = n_cols = 3
+    cell_size = 10.0
     grid = models.Grid.from_bbox(
-        x_min=0.0, x_max=30.0, y_min=0.0, y_max=30.0, n_rows=3, n_cols=3
+        x_min=0.0, x_max=30.0, y_min=0.0, y_max=30.0, n_rows=n_rows, n_cols=n_cols
     )
 
-    center = grid.cells[4]  # row 1, col 1: fully interior, no padding anywhere
-    assert center.x_min == pytest.approx(10.0)
-    assert center.x_max == pytest.approx(20.0)
-    assert center.y_min == pytest.approx(10.0)
-    assert center.y_max == pytest.approx(20.0)
+    for row in range(n_rows):
+        for col in range(n_cols):
+            cell = grid.cells[row * n_cols + col]
 
-    middle_right = grid.cells[5]  # row 1, col 2: padded only on the right edge
-    assert middle_right.x_min == pytest.approx(20.0)
-    assert middle_right.x_max == pytest.approx(30.1)
-    assert middle_right.y_min == pytest.approx(10.0)
-    assert middle_right.y_max == pytest.approx(20.0)
+            expected_x_min = col * cell_size - (padding if col == 0 else 0.0)
+            expected_x_max = (col + 1) * cell_size + (
+                padding if col == n_cols - 1 else 0.0
+            )
+            # Rows run top-to-bottom, so row 0 is the top of the [0, 30] range.
+            expected_y_max = (n_rows - row) * cell_size + (padding if row == 0 else 0.0)
+            expected_y_min = (n_rows - row - 1) * cell_size - (
+                padding if row == n_rows - 1 else 0.0
+            )
+
+            assert cell.x_min == pytest.approx(expected_x_min)
+            assert cell.x_max == pytest.approx(expected_x_max)
+            assert cell.y_min == pytest.approx(expected_y_min)
+            assert cell.y_max == pytest.approx(expected_y_max)
 
 
 @pytest.mark.parametrize("padding", [0.1, 1.0], ids=["default", "custom"])


### PR DESCRIPTION
## Summary
Adds a `Grid` dataclass to `models.py` and a `segment_strokes()` in `alphabet_utils.py`. `Grid` owns a list of `GridCell` objects and provides a `from_bbox` factory for subdivision and `get_cell_for_point` for lookup. `segment_strokes()` groups drawing data by `line_number`, creates `Stroke` objects, and assigns each to a cell by centroid.

## Notes
- `from_bbox` pads the outer grid edges by a small amount (default 0.1) so that centroids landing exactly on the boundaries are not excluded
- Strokes whose centroids fall outside the grid are silently dropped