### PR TITLE
hotfix: avoid circular import between models and config

### DIFF
--- a/src/graphomotor/core/models.py
+++ b/src/graphomotor/core/models.py
@@ -9,8 +9,6 @@ import pandas as pd
 import pydantic
 import scipy.spatial.distance as dist
 
-from graphomotor.core import config
-
 
 class Drawing(pydantic.BaseModel):
     """Class representing a drawing task, encapsulating both raw data and metadata.
@@ -506,6 +504,8 @@ class LineSegment:
                 CircleTarget instances (output of load_scaled_circles in config).
             trail_id: Trail identifier for circle lookup.
         """
+        from graphomotor.core import config
+
         logger = config.get_logger()
         trail_circles = circles[trail_id]
         points = self.points.copy()


### PR DESCRIPTION
## Summary
This hotfix resolves a circular import path between `graphomotor.core.models` and `graphomotor.core.config`.
Resolves #124 

`config.py` imports `models.py` at module load time (for `CircleTarget` usage in circle-loading utilities). `models.py` previously imported `config.py` at module level only to access logging inside `LineSegment.calculate_metrics`, which created a circular import risk.

- Removed module-level import in `models.py`.
- Added a local import inside `LineSegment.calculate_metrics` right before logger usage.

## Notes
This is intentionally a hotfix. A broader cleanup such as extracting logging utilities from `config` should be handled separately if desired, but is not required for this fix.